### PR TITLE
Cache mongo client, not client promise

### DIFF
--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -7,27 +7,24 @@ if (!process.env.MONGODB_URI) {
 const uri = process.env.MONGODB_URI;
 const options = {};
 
-let client;
-let clientPromise: Promise<MongoClient>;
+let client: MongoClient;
 
 if (process.env.NODE_ENV === "development") {
   // In development mode, use a global variable so that the value
   // is preserved across module reloads caused by HMR (Hot Module Replacement).
   let globalWithMongo = global as typeof globalThis & {
-    _mongoClientPromise?: Promise<MongoClient>;
+    _mongoClient?: MongoClient;
   };
 
-  if (!globalWithMongo._mongoClientPromise) {
-    client = new MongoClient(uri, options);
-    globalWithMongo._mongoClientPromise = client.connect();
+  if (!globalWithMongo._mongoClient) {
+    globalWithMongo._mongoClient = new MongoClient(uri, options);
   }
-  clientPromise = globalWithMongo._mongoClientPromise;
+  client = globalWithMongo._mongoClient;
 } else {
   // In production mode, it's best to not use a global variable.
   client = new MongoClient(uri, options);
-  clientPromise = client.connect();
 }
 
-// Export a module-scoped MongoClient promise. By doing this in a
+// Export a module-scoped MongoClient. By doing this in a
 // separate module, the client can be shared across functions.
-export default clientPromise;
+export default client;

--- a/pages/api/movies.tsx
+++ b/pages/api/movies.tsx
@@ -1,9 +1,8 @@
-import clientPromise from "../../lib/mongodb";
+import client from "../../lib/mongodb";
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
     try {
-        const client = await clientPromise;
         const db = client.db("sample_mflix");
         const movies = await db
             .collection("movies")

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import clientPromise from "../lib/mongodb";
+import client from "../lib/mongodb";
 import type { InferGetServerSidePropsType, GetServerSideProps } from "next";
 
 type ConnectionStatus = {
@@ -10,8 +10,8 @@ export const getServerSideProps: GetServerSideProps<
   ConnectionStatus
 > = async () => {
   try {
-    await clientPromise;
-    // `await clientPromise` will use the default database passed in the MONGODB_URI
+    await client.connect();
+    // `await client.connect()` will use the default database passed in the MONGODB_URI
     // However you can use another database (e.g. myDatabase) by replacing the `await clientPromise` with the following code:
     //
     // `const client = await clientPromise`

--- a/pages/movies.tsx
+++ b/pages/movies.tsx
@@ -1,4 +1,4 @@
-import clientPromise from "../lib/mongodb";
+import client from "../lib/mongodb";
 import { GetServerSideProps } from 'next';
 
 interface Movie {
@@ -36,7 +36,6 @@ export default Movies;
 
 export const getServerSideProps: GetServerSideProps = async () => {
     try {
-        const client = await clientPromise;
         const db = client.db("sample_mflix");
         const movies = await db
             .collection("movies")

--- a/pages/top.tsx
+++ b/pages/top.tsx
@@ -1,5 +1,5 @@
 import { ObjectId } from "mongodb";
-import clientPromise from "../lib/mongodb";
+import client from "../lib/mongodb";
 import { GetStaticProps } from "next";
 
 interface Movie {
@@ -35,8 +35,6 @@ export default function Top({ movies }: TopProps) {
 
 export const getStaticProps: GetStaticProps<TopProps> = async () => {
     try {
-        const client = await clientPromise;
-
         const db = client.db("sample_mflix");
 
         const movies = await db


### PR DESCRIPTION
Caching the client's promise can lead to unhandled promise rejections if the client fails to connect.  Caching the client avoids this pitfall.

The mongo client will auto connect on the first operation.